### PR TITLE
 função applyPaginate

### DIFF
--- a/src/common/domain/repositories/in-memory.repository.spec.ts
+++ b/src/common/domain/repositories/in-memory.repository.spec.ts
@@ -150,7 +150,9 @@ describe('InMemoryRepository unit tests', () => {
       expect(spyFilterMethod).toHaveBeenCalledTimes(3)
       expect(result).toHaveLength(0)
     })
+  })
 
+  describe('applySort', () => {
     it('should not sort items', async () => {
       const items = [
         { id: randomUUID(), name: 'test', price: 10, created_at, updated_at },
@@ -162,6 +164,19 @@ describe('InMemoryRepository unit tests', () => {
 
       result = await sut['applySort'](items, 'id', 'asc')
       expect(result).toStrictEqual(items)
+    })
+
+    it('should sort items', async () => {
+      const items = [
+        { id: randomUUID(), name: 'b', price: 10, created_at, updated_at },
+        { id: randomUUID(), name: 'a', price: 20, created_at, updated_at },
+        { id: randomUUID(), name: 'c', price: 30, created_at, updated_at },
+      ]
+      let result = await sut['applySort'](items, 'name', 'desc')
+      expect(result).toStrictEqual([items[2], items[0], items[1]])
+
+      result = await sut['applySort'](items, 'name', 'asc')
+      expect(result).toStrictEqual([items[1], items[0], items[2]])
     })
   })
 })

--- a/src/common/domain/repositories/in-memory.repository.spec.ts
+++ b/src/common/domain/repositories/in-memory.repository.spec.ts
@@ -179,4 +179,27 @@ describe('InMemoryRepository unit tests', () => {
       expect(result).toStrictEqual([items[1], items[0], items[2]])
     })
   })
+
+  describe('applyPaginate', () => {
+    it('should paginate items', async () => {
+
+      const items = [
+        { id: randomUUID(), name: 'b', price: 10, created_at, updated_at },
+        { id: randomUUID(), name: 'a', price: 20, created_at, updated_at },
+        { id: randomUUID(), name: 'c', price: 30, created_at, updated_at },
+        { id: randomUUID(), name: 'd', price: 10, created_at, updated_at },
+        { id: randomUUID(), name: 'e', price: 20, created_at, updated_at },
+      ]
+
+      let result = await sut['applyPaginate'](items, 1, 2)
+      expect(result).toStrictEqual([items[0], items[1]])
+
+      result = await sut['applyPaginate'](items, 2, 2)
+      expect(result).toStrictEqual([items[2], items[3]])
+
+      result = await sut['applyPaginate'](items, 2, 3)
+      expect(result).toStrictEqual([items[3], items[4]])
+
+    })
+  })
 })


### PR DESCRIPTION
Esse código testa se a função applyPaginate está corretamente implementada para paginar uma lista de itens, garantindo que os resultados correspondam aos itens esperados em diferentes páginas e tamanhos de página. Se algum dos testes falhar, isso indicará que a lógica de paginação pode estar incorreta.