### PR TITLE
Adiciona teste de paginação ao método search no repositório in-memory

### DIFF
--- a/src/common/domain/repositories/in-memory.repository.spec.ts
+++ b/src/common/domain/repositories/in-memory.repository.spec.ts
@@ -219,4 +219,45 @@ describe('InMemoryRepository unit tests', () => {
       })
     })
   })
+
+  describe('search', () => {
+    it('should paginate items', async () => { 
+      const items = Array(16).fill(model)
+      sut.items = items
+      const result = await sut.search({ filter: null })
+      expect(result).toStrictEqual({
+        items: Array(15).fill(model),
+        total: 16,
+        current_page: 1,
+        per_page: 15,
+        sort: null,
+        sort_dir: null,
+        filter: null,
+      })
+    })
+
+    it('should paginate a filtered list', async () => { 
+      const items = [
+        { id: randomUUID(), name: 'test', price: 10, created_at, updated_at },
+        { id: randomUUID(), name: 'a', price: 20, created_at, updated_at },
+        { id: randomUUID(), name: 'TESTE', price: 30, created_at, updated_at },
+        { id: randomUUID(), name: 'TeSt', price: 10, created_at, updated_at },
+      ]
+      sut.items = items
+      const result = await sut.search({
+        page: 1,
+        per_page: 2,
+        filter: 'test',
+      })
+      expect(result).toStrictEqual({
+        items: [items[0], items[2]],
+        total: 3,
+        current_page: 1,
+        per_page: 2,
+        sort: null,
+        sort_dir: null,
+        filter: 'test',
+      })
+    })
+  })
 })

--- a/src/common/domain/repositories/in-memory.repository.ts
+++ b/src/common/domain/repositories/in-memory.repository.ts
@@ -67,6 +67,7 @@ export abstract class InMemoryRepository<Model extends ModelProps>
       page,
       per_page,
     )
+    
     return {
       items: paginatedItems,
       total: filteredItems.length,


### PR DESCRIPTION
Este pull request adiciona um teste unitário para o método search do repositório em memória. O teste verifica se a paginação funciona corretamente quando há mais de 15 itens no array.

**Alterações incluídas:**

- Adiciona describe('search', ...) com o teste should paginate items

- **Garante que o método retorna corretamente:**

- os primeiros 15 itens

- o total de itens como 16

- metadados corretos (página atual, itens por página, etc.)