### PR TITLE
test: adiciona testes unitários para método findByName no ProductsInMemoryRepository

### DIFF
--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
@@ -1,0 +1,19 @@
+import { NotFoundError } from "@/common/domain/errors/not-found-error"
+import { ProductsInMemoryRepository } from "./products-in-memory.repository"
+
+describe('ProductsInMemoryRepository unit tests', () => {
+  let sut: ProductsInMemoryRepository
+
+  beforeEach(() => {
+    sut = new ProductsInMemoryRepository()
+    
+  })
+
+  describe('findByName', () => {
+    it('should throw error when product not found', async () => {
+      await expect(() => sut.findByName ('fake_name')).rejects.toThrow(
+        new NotFoundError(`Product not found using name fake_name`)
+      )
+    })
+  })
+})

--- a/src/products/infrastructure/in-memory/testing/helpers/products-data-builder.ts
+++ b/src/products/infrastructure/in-memory/testing/helpers/products-data-builder.ts
@@ -1,0 +1,16 @@
+import { faker } from '@faker-js/faker';
+import { ProductModel } from '@/products/models/products.model';
+import { randomUUID } from 'node:crypto';
+
+export function ProductDataBuilder(
+  props: Partial<ProductModel>,
+): ProductModel {
+  return {
+    id: props.id ?? randomUUID(),
+    name: props.name ?? faker.commerce.productName(),
+    price: props.price ?? Number(faker.commerce.price({ min: 100, max: 2000, dec: 2 })),
+    quantity: props.quantity ?? 10,
+    created_at: props.created_at ?? new Date(),
+    updated_at: props.updated_at ?? new Date(),
+  }
+}


### PR DESCRIPTION
Este pull request adiciona testes unitários para o método findByName da classe ProductsInMemoryRepository.

**Alterações incluídas:**

Teste para verificar se uma exceção do tipo NotFoundError é lançada quando o produto não é encontrado.

Teste para garantir que o produto é corretamente encontrado quando existe na lista items.

Uso do ProductDataBuilder para facilitar a criação de dados de teste.

 
