### PR TITLE
test: improve coverage of applyFilter method in ProductsInMemoryRepository

### DIFF
--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
@@ -13,11 +13,8 @@ describe('ProductsInMemoryRepository unit tests', () => {
 
   describe('findByName', () => {
     it('should throw error when product not found', async () => {
-      const data = ProductDataBuilder({ name: 'Curso nodejs'})
-      
-
-      await expect(() => sut.conflictingName('Curso nodejs')).rejects.toThrow(
-        new ConflictError(`Product not found using name fake_name`)
+      await expect(() => sut.findByName ('fake_name')).rejects.toThrow(
+        new NotFoundError(`Product not found using name fake_name`)
       )
 
       await expect(() => sut.findByName ('fake_name')).rejects.toBeInstanceOf(NotFoundError)
@@ -32,21 +29,21 @@ describe('ProductsInMemoryRepository unit tests', () => {
     
   })
 
-  describe('findByName', () => {
-    it('should throw error when product found', async () => {
-      await expect(() => sut.findByName ('fake_name')).rejects.toThrow(
-        new NotFoundError(`Product not found using name fake_name`)
-      )
+  describe('conflictingName', () => {
+      it('should throw error when product not found', async () => {
+        const data = ProductDataBuilder({ name: 'Curso nodejs' })
+        sut.items.push(data)
 
-      await expect(() => sut.findByName ('fake_name')).rejects.toBeInstanceOf(NotFoundError)
-    })
+        await expect(() => sut.conflictingName('Curso nodejs')).rejects.toThrow(
+          new ConflictError(`Name already used on another product: Curso nodejs`)
+        )
 
-    // it('should find product by name', async () => {
-    //   const data = ProductDataBuilder({ name: 'Curso nodejs'})
-    //   sut.items.push(data)
-    //   const result = await sut.findByName('Curso nodejs')
-    //   expect(result).toEqual(data)
-    // })
-    
+        await expect(() => sut.conflictingName('Curso nodejs')).rejects.toBeInstanceOf(ConflictError)
+      })
+
+      it('should not find product by name', async () => {
+        expect.assertions(0)
+        await sut.conflictingName('Curso nodejs')
+      })
   })
 })

--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
@@ -46,4 +46,32 @@ describe('ProductsInMemoryRepository unit tests', () => {
         await sut.conflictingName('Curso nodejs')
       })
   })
+
+  describe('applyFilter', () => {
+      it('should no filter items when filter param is null', async () => {
+        const data = ProductDataBuilder({})
+        sut.items.push(data)
+
+        const spyFilterMethod = jest.spyOn(sut.items, 'filter' as any)
+        const result = await sut['applyFilter'](sut.items, null)
+        expect(spyFilterMethod).not.toHaveBeenCalled()
+        expect(result).toStrictEqual(sut.items)
+      })
+  
+      it('should filter the data using filter param', async () => {
+        const items = [
+          ProductDataBuilder({ name: 'Test' }),
+          ProductDataBuilder({ name: 'TEST' }),
+          ProductDataBuilder({ name: 'fake' }),
+        ]
+        sut.items.push(...items)
+
+        const spyFilterMethod = jest.spyOn(Array.prototype, 'filter')
+        const result = await sut['applyFilter'](sut.items, 'TEST')
+        expect(spyFilterMethod).toHaveBeenCalled()
+        expect(result).toStrictEqual([items[0], items[1]])
+
+        spyFilterMethod.mockRestore() // restaura o método original após o teste
+      })
+  })
 })

--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from "@/common/domain/errors/not-found-error"
 import { ProductsInMemoryRepository } from "./products-in-memory.repository"
 import { ProductDataBuilder } from "../testing/helpers/products-data-builder"
+import { ConflictError } from "@/common/domain/errors/not-found-conflict-error"
 
 describe('ProductsInMemoryRepository unit tests', () => {
   let sut: ProductsInMemoryRepository
@@ -12,8 +13,11 @@ describe('ProductsInMemoryRepository unit tests', () => {
 
   describe('findByName', () => {
     it('should throw error when product not found', async () => {
-      await expect(() => sut.findByName ('fake_name')).rejects.toThrow(
-        new NotFoundError(`Product not found using name fake_name`)
+      const data = ProductDataBuilder({ name: 'Curso nodejs'})
+      
+
+      await expect(() => sut.conflictingName('Curso nodejs')).rejects.toThrow(
+        new ConflictError(`Product not found using name fake_name`)
       )
 
       await expect(() => sut.findByName ('fake_name')).rejects.toBeInstanceOf(NotFoundError)
@@ -25,5 +29,24 @@ describe('ProductsInMemoryRepository unit tests', () => {
       const result = await sut.findByName('Curso nodejs')
       expect(result).toEqual(data)
     })
+    
+  })
+
+  describe('findByName', () => {
+    it('should throw error when product found', async () => {
+      await expect(() => sut.findByName ('fake_name')).rejects.toThrow(
+        new NotFoundError(`Product not found using name fake_name`)
+      )
+
+      await expect(() => sut.findByName ('fake_name')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    // it('should find product by name', async () => {
+    //   const data = ProductDataBuilder({ name: 'Curso nodejs'})
+    //   sut.items.push(data)
+    //   const result = await sut.findByName('Curso nodejs')
+    //   expect(result).toEqual(data)
+    // })
+    
   })
 })

--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from "@/common/domain/errors/not-found-error"
 import { ProductsInMemoryRepository } from "./products-in-memory.repository"
+import { ProductDataBuilder } from "../testing/helpers/products-data-builder"
 
 describe('ProductsInMemoryRepository unit tests', () => {
   let sut: ProductsInMemoryRepository
@@ -14,6 +15,15 @@ describe('ProductsInMemoryRepository unit tests', () => {
       await expect(() => sut.findByName ('fake_name')).rejects.toThrow(
         new NotFoundError(`Product not found using name fake_name`)
       )
+
+      await expect(() => sut.findByName ('fake_name')).rejects.toBeInstanceOf(NotFoundError)
+    })
+
+    it('should find product by name', async () => {
+      const data = ProductDataBuilder({ name: 'Curso nodejs'})
+      sut.items.push(data)
+      const result = await sut.findByName('Curso nodejs')
+      expect(result).toEqual(data)
     })
   })
 })

--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.ts
@@ -34,7 +34,7 @@ export class ProductsInMemoryRepository
   async conflictingName(name: string): Promise<void> {
     const product = this.items.find(item => item.name === name)
     if(product) {
-      throw new ConflictError(`Product not found using name ${name}`)
+      throw new ConflictError(`Name already used on another product: ${name}`)
     }
   }
 


### PR DESCRIPTION
Este PR adiciona testes unitários específicos para o método applyFilter do repositório ProductsInMemoryRepository.

Alterações:
Adicionado teste para garantir que nenhum filtro é aplicado quando o parâmetro é null

Adicionado teste para verificar o comportamento correto do filtro com parâmetro fornecido

Uso do jest.spyOn(Array.prototype, 'filter') para monitorar chamadas de .filter()

Uso de mockRestore() para restaurar o método original após o teste

Motivo:
Esses testes ajudam a garantir que o método applyFilter funcione corretamente tanto com como sem parâmetro de filtro, melhorando a cobertura e a confiabilidade da lógica de busca.