### PR TITLE
test: ensure applySort orders by created_at when sort param is null

### DIFF
--- a/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
+++ b/src/products/infrastructure/in-memory/repositories/products-in-memory.repository.spec.ts
@@ -74,4 +74,34 @@ describe('ProductsInMemoryRepository unit tests', () => {
         spyFilterMethod.mockRestore() // restaura o método original após o teste
       })
   })
+
+  describe('applySort', () => {
+    it('should sort items by created_at when sort param is null', async () => {
+        const created_at = new Date()
+        const items = [
+          ProductDataBuilder({ name: 'c', created_at: created_at }),
+          ProductDataBuilder({
+            name: 'a',
+            created_at: new Date(created_at.getTime() + 100),
+          }),
+          ProductDataBuilder({
+            name: 'b',
+            created_at: new Date(created_at.getTime() + 200),
+          }),
+        ]
+        sut.items.push(...items)
+        const result = await sut['applySort'](sut.items, null, null)
+        expect(result).toStrictEqual([items[2], items[1], items[0]])
+      })
+      it('should sort items by name field', async () => {
+        const items = [
+          ProductDataBuilder({ name: 'c' }),
+          ProductDataBuilder({ name: 'a' }),
+          ProductDataBuilder({ name: 'b' }),
+        ]
+        sut.items.push(...items)
+        const result = await sut['applySort'](sut.items, 'name', 'desc')
+        expect(result).toStrictEqual([items[0], items[2], items[1]])
+      })
+    })
 })


### PR DESCRIPTION
### Descrição

Este PR adiciona testes à função `applySort` do repositório in-memory de produtos, garantindo os seguintes comportamentos:

- Quando o parâmetro `sort` é `null`, os itens devem ser ordenados por `created_at` em ordem decrescente.
- Quando o parâmetro `sort` é `'name'` e a ordem é `'desc'`, os itens devem ser ordenados alfabeticamente de Z para A.

### Alterações

- Adicionado o teste `should sort items by created_at when sort param is null`
- Adicionado o teste `should sort items by name field` com ordenação descendente

### Como testar

1. Rode os testes com `npm test` ou `yarn test`.
2. Verifique se a suite `applySort` passa corretamente com os novos testes.

### Evidência de execução

