### PR TITLE
Implementação do método _get para buscar produtos por ID

### DIFF
--- a/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.ts
+++ b/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.ts
@@ -49,4 +49,10 @@ export class ProductsTypeormRepository implements ProductsRepository {
   search(props: SearchInput): Promise<SearchOutput<ProductModel>> {
     throw new Error("Method not implemented.");
   }
+
+  protected async _get(id: string): Promise<ProductModel> {
+    const product = await this.productsRepository.findOneBy({ id });
+    if (!product) throw new Error("Product not found");
+    return product;
+  } 
 }


### PR DESCRIPTION
Este pull request introduz o método protegido _get, que permite a busca de um produto pelo seu ID. O método utiliza o repositório de produtos para encontrar o produto correspondente e lança um erro caso o produto não seja encontrado.

**Mudanças Realizadas**

- Adicionada a implementação do método _get na classe que gerencia os produtos.

- Lançamento de um erro se o produto não for encontrado.