### PR TITLE
ajuste: melhora configuração do Jest com suporte a paths do tsconfig

### DIFF
--- a/jest.int.config.ts
+++ b/jest.int.config.ts
@@ -1,0 +1,16 @@
+import { pathsToModuleNameMapper } from 'ts-jest'
+import { compilerOptions } from './tsconfig.json'
+
+export default {
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  }),
+  testRegex: '.*\\.int-spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "npx dotenv-cli -e .env -- ts-node-dev -r tsconfig-paths/register --inspect --transpile-only --ignore-watch node_modules src/common/infrastructure/http/server.ts",
     "lint": "eslint .",
     "test": "npx dotenv-cli -e .env.test -- jest --runInBand",
-    "typeorm": "ts-node-dev -r tsconfig-paths/register --transpile-only ./node_modules/typeorm/cli.js"
+    "typeorm": "ts-node-dev -r tsconfig-paths/register --transpile-only ./node_modules/typeorm/cli.js",
+    "pretest:int": "docker run --name testsdb -e POSTGRES_PASSWORD=postgres -p 5433:5432 -d postgres",
+    "test:int": "npx dotenv-cli -e .env.test -- jest --runInBand --config ./jest.int.config.ts",
+    "posttest:int": "docker stop testsdb && docker rm testsdb"
   },
   "keywords": [],
   "author": "",

--- a/src/common/infrastructure/typeorm/typeorm/testing/data-source.ts
+++ b/src/common/infrastructure/typeorm/typeorm/testing/data-source.ts
@@ -1,0 +1,16 @@
+import { DataSource } from 'typeorm'
+import { env } from '@/common/infrastructure/env'
+
+export const testDataSource = new DataSource({
+  type: env.DB_TYPE,
+  host: env.DB_HOST,
+  port: env.DB_PORT,
+  username: env.DB_USER,
+  password: env.DB_PASS,
+  database: env.DB_NAME,
+  schema: env.DB_SCHELMA,
+  entities: ['**/entities/**/*.ts'],
+  migrations: ['**/migrations/**/*.ts'],
+  synchronize: true,
+  logging: true,
+})


### PR DESCRIPTION
**Este PR ajusta a configuração do Jest para teste de produtos.**

**Descrição dos scripts de teste de integração:**
pretest:int: Inicializa um container Docker com o PostgreSQL antes dos testes. A senha é postgres e a porta 5433 é usada para evitar conflito com a porta padrão (5432).

**test:int:** Executa os testes de integração com Jest utilizando variáveis de ambiente definidas em .env.test, garantindo que os testes rodem em sequência (--runInBand).

**posttest:int:** Encerra e remove o container Docker usado para os testes, garantindo que não fiquem containers órfãos.

