### PR TITLE
test: add integration test for ProductsTypeormRepository.findById

### DIFF
--- a/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
@@ -5,11 +5,11 @@ describe('ProductsTypeormRepository integrations tests', () => {
   let productsRepository: ProductsTypeormRepository
 
   beforeAll(async() => {
-     await testDataSource.initialize() 
+    await testDataSource.initialize() 
   })
 
-  afterAll(() => {
-
+  afterAll(async() => {
+    await testDataSource.destroy()
   })
 
   beforeEach(() => {

--- a/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
@@ -1,7 +1,16 @@
+import { testDataSource } from "@/common/infrastructure/typeorm/typeorm/testing/data-source";
 import { ProductsTypeormRepository } from "./product-typeorm.repository";
 
 describe('ProductsTypeormRepository integrations tests', () => {
   let productsRepository: ProductsTypeormRepository
+
+  beforeAll(async() => {
+     await testDataSource.initialize() 
+  })
+
+  afterAll(() => {
+
+  })
 
   beforeEach(() => {
     

--- a/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
@@ -1,6 +1,9 @@
 import { testDataSource } from "@/common/infrastructure/typeorm/typeorm/testing/data-source";
 import { ProductsTypeormRepository } from "./product-typeorm.repository";
 import { Product } from "../entities/products.entity";
+import { Not } from "typeorm";
+import { NotFoundError } from "@/common/domain/errors/not-found-error";
+import { randomUUID } from "crypto";
 
 describe('ProductsTypeormRepository integrations tests', () => {
   let ormRepository: ProductsTypeormRepository
@@ -19,9 +22,12 @@ describe('ProductsTypeormRepository integrations tests', () => {
     ormRepository.productsRepository = testDataSource.getRepository(Product)
   })
 
-  describe('method', () => {
-    it('testing', () => {
-    
+  describe('findById', () => {
+    it('should gerenerate an error when the product is not found', async () => {
+      const id = randomUUID()
+      await expect(ormRepository.findById(id)).rejects.toThrow(
+        new NotFoundError(`Product not found using ID ${id}`),
+      )
     })
   })
 });

--- a/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
@@ -1,8 +1,9 @@
 import { testDataSource } from "@/common/infrastructure/typeorm/typeorm/testing/data-source";
 import { ProductsTypeormRepository } from "./product-typeorm.repository";
+import { Product } from "../entities/products.entity";
 
 describe('ProductsTypeormRepository integrations tests', () => {
-  let productsRepository: ProductsTypeormRepository
+  let ormRepository: ProductsTypeormRepository
 
   beforeAll(async() => {
     await testDataSource.initialize() 
@@ -14,6 +15,8 @@ describe('ProductsTypeormRepository integrations tests', () => {
 
   beforeEach(async() => {
     await testDataSource.manager.query('DELETE from products')
+    ormRepository = new ProductsTypeormRepository()
+    ormRepository.productsRepository = testDataSource.getRepository(Product)
   })
 
   describe('method', () => {

--- a/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/product-typeorm.repository.int-spec.ts
@@ -12,8 +12,8 @@ describe('ProductsTypeormRepository integrations tests', () => {
     await testDataSource.destroy()
   })
 
-  beforeEach(() => {
-    
+  beforeEach(async() => {
+    await testDataSource.manager.query('DELETE from products')
   })
 
   describe('method', () => {


### PR DESCRIPTION
Este PR adiciona um teste de integração para o método findById da classe ProductsTypeormRepository.

 **Alterações incluídas:**

Criação da suíte de testes ProductsTypeormRepository integrations tests

Inicialização e destruição do testDataSource usando os hooks beforeAll e afterAll

Limpeza da tabela products e instanciação do repositório em beforeEach

Adição do teste should generate an error when the product is not found para validar o erro lançado ao tentar buscar um produto inexistente

 **Teste incluído:**

Verifica se findById lança um NotFoundError com a mensagem correta ao não encontrar um produto pelo ID