### PR TITLE
Implementa busca de produto por nome (findByName)

### DIFF
--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
@@ -101,7 +101,6 @@ describe('ProductsTypeormRepository integrations tests', () => {
       const data = ProductsDataBuilder({})
       const product = testDataSource.manager.create(Product, data)
       await testDataSource.manager.save(product)
- 
       await ormRepository.delete(data.id)
 
       const result = await testDataSource.manager.findOneBy(Product, {
@@ -109,6 +108,25 @@ describe('ProductsTypeormRepository integrations tests', () => {
       })
       
       expect(result).toBeNull()
+    })
+  })
+
+  
+  describe('findByName', () => {
+    it('should generate an error when the product is not found', async () => {
+      const name = 'Product 1'
+      await expect(ormRepository.findByName(name)).rejects.toThrow(
+        new NotFoundError(`Product not found using Name ${name}`),
+      )
+    })
+
+    it('should finds a product by name', async () => {
+      const data = ProductsDataBuilder({ name: 'Product 1'})
+      const product = testDataSource.manager.create(Product, data)
+      await testDataSource.manager.save(product)
+
+      const result = await ormRepository.findByName(product.name)
+      expect(result.name).toEqual('Product 1')
     })
   })
 

--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
@@ -15,7 +15,7 @@ export class ProductsTypeormRepository implements ProductsRepository {
     this.productsRepository = dataSource.getRepository(Product);
   }
 
-  protected async findByName(name: string): Promise<ProductModel> {
+  async findByName(name: string): Promise<ProductModel> {
     const product = await this.productsRepository.findOneBy({ name });
 
     if (!product) {

--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
@@ -15,8 +15,14 @@ export class ProductsTypeormRepository implements ProductsRepository {
     this.productsRepository = dataSource.getRepository(Product);
   }
 
-  findByName(name: string): Promise<ProductModel> {
-    throw new Error("Method not implemented.");
+  protected async findByName(name: string): Promise<ProductModel> {
+    const product = await this.productsRepository.findOneBy({ name });
+
+    if (!product) {
+      throw new NotFoundError(`Product not found using Name ${name}`);
+    }
+
+    return product;
   }
 
   findAllByIds(ids: ProductId[]): Promise<ProductModel[]> {


### PR DESCRIPTION
Este Pull Request adiciona ao repositório de produtos o método findByName, permitindo recuperar um produto a partir do seu nome. Caso o produto não exista, uma exceção do tipo NotFoundError é lançada.


**O que foi feito**

- Implementação do método findByName(name: string): Promise<ProductModel> no repositório.

- O método realiza a busca utilizando findOneBy({ name }).

- Adicionada validação para lançar erro caso nenhum produto seja encontrado.

- Inclusão de testes unitários cobrindo:

- O caso de erro quando o produto não é encontrado.

- A busca bem-sucedida de um produto existente.

**Testes**

- Foram incluídos dois testes no bloco findByName:

- should generate an error when the product is not found: garante que a exceção NotFoundError é lançada corretamente.

- should finds a product by name: cria um produto com nome fixo, salva no banco, e verifica se ele pode ser recuperado pelo nome.