### PR TITLE
Teste findAllByIds typeorm respository

### DIFF
--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
@@ -143,4 +143,29 @@ describe('ProductsTypeormRepository integrations tests', () => {
     })
   })
 
+  describe('findAllByIds', () => {
+    it('should return an empty array when not find the products', async () => {
+      const productsIds = [
+        { id: 'e0b242a9-9606-4b25-ad24-8e6e2207ae45' },
+        { id: randomUUID() },
+      ]
+      const result = await ormRepository.findAllByIds(productsIds)
+      expect(result).toEqual([])
+      expect(result).toHaveLength(0)
+    })
+
+    it('should find the products by the id field', async () => {
+      const productsIds = [
+        { id: 'e0b242a9-9606-4b25-ad24-8e6e2207ae45' },
+        { id: randomUUID() },
+      ]
+
+      const data = ProductsDataBuilder({ id: productsIds[0].id })
+      const product = testDataSource.manager.create(Product, data)
+      await testDataSource.manager.save(product)
+
+      const result = await ormRepository.findAllByIds(productsIds)
+      expect(result).toHaveLength(1)
+    })
+  })
 });

--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
@@ -26,14 +26,14 @@ export class ProductsTypeormRepository implements ProductsRepository {
     return product;
   }
 
-  async findAllByIds(productsIds[]): Promise<ProductModel[]> {
-    const ids = productsIds.map((productId) => productId.id)
+  async findAllByIds(productsIds: { id: string }[]): Promise<ProductModel[]> {
+    const ids = productsIds.map((productId) => productId.id);
 
     const productsFound = await this.productsRepository.find({
-      where: {id: In(ids)}
-    })
+      where: { id: In(ids) }
+    });
 
-    return productsFound
+    return productsFound;
   }
 
   async conflictingName(name: string): Promise<void> {


### PR DESCRIPTION
Este Pull Request adiciona ao repositório de produtos a funcionalidade de buscar múltiplos produtos a partir de uma lista de IDs. A funcionalidade é útil em cenários onde é necessário validar ou recuperar vários registros de forma eficiente.