### PR TITLE
Adiciona teste para paginação na busca de produtos

### DIFF
--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
@@ -168,4 +168,27 @@ describe('ProductsTypeormRepository integrations tests', () => {
       expect(result).toHaveLength(1)
     })
   })
+
+  describe('search', () => {
+    it('should  apply only pagination when the other params are null', async () => {
+      const arrange = Array(16).fill(ProductsDataBuilder({}))
+      arrange.map(element => delete element.id)
+      const data = testDataSource.manager.create(Product, arrange)
+      await testDataSource.manager.save(data)
+
+      const result = await ormRepository.search({ 
+        page: 1, 
+        per_page: 15, 
+        filter: null, 
+        sort: null, 
+        sort_dir: null,
+      })
+
+      expect(result.total).toEqual(16)
+      expect(result.items.length).toEqual(15)
+    })
+  })
+
+
+
 });

--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.ts
@@ -70,7 +70,7 @@ export class ProductsTypeormRepository implements ProductsRepository {
   async search(props: SearchInput): Promise<SearchOutput<ProductModel>> {
     const validSort = this.sortableFields.includes(props.sort) || false
     const dirOps = ['asc','desc']
-    const validSortDir = dirOps.includes(props.sort_dir.toLowerCase()) || false
+    const validSortDir = (props.sort_dir && dirOps.includes(props.sort_dir.toLowerCase())) || false
     const orderByField = validSort ? props.sort : 'created_at'
     const orderByDir = validSortDir ? props.sort_dir : 'desc'
 


### PR DESCRIPTION
Este PR adiciona um teste à suíte de testes da funcionalidade de search no repositório ProductRepository.
O teste verifica se a paginação é corretamente aplicada mesmo quando os demais parâmetros (filter, sort, sort_dir) são null.

**O que foi testado**

Quando os parâmetros de filtro e ordenação são null, a busca deve considerar apenas a paginação.

Foram inseridos 16 produtos no banco (sem id definido para simular inserções novas).

A busca foi feita com per_page = 15 e page = 1.

**Verificações:**

result.total deve ser 16

result.items.length deve ser 15