### PR TITLE
Adiciona teste de paginação e ordenação no método search

### DIFF
--- a/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
+++ b/src/products/infrastructure/typeorm/respositories/products-typeorm.repository.int-spec.ts
@@ -177,7 +177,7 @@ describe('ProductsTypeormRepository integrations tests', () => {
       const data = testDataSource.manager.create(Product, arrange)
       await testDataSource.manager.save(data)
 
-      const result = await ormRepository.search({ 
+      let result = await ormRepository.search({ 
         page: 1, 
         per_page: 15, 
         filter: null, 
@@ -187,6 +187,7 @@ describe('ProductsTypeormRepository integrations tests', () => {
 
       expect(result.total).toEqual(16)
       expect(result.items.length).toEqual(15)
+      expect(result.sort).toEqual('created_at')
     })
   })
 
@@ -220,4 +221,44 @@ describe('ProductsTypeormRepository integrations tests', () => {
 
   })
 
+  it('should apply paginate and sort', async () => {
+      const created_at = new Date()
+      const models: ProductModel[] = []
+      
+      'badec'.split('').forEach((element, index) => {
+          models.push({
+            ...ProductsDataBuilder({}),
+            name: element,
+            created_at: new Date(created_at.getTime() + index)
+          })
+      })
+
+      const data = testDataSource.manager.create(Product, models)
+      await testDataSource.manager.save(data)
+
+      let result = await ormRepository.search({ 
+        page: 1, 
+        per_page: 2, 
+        filter: null, 
+        sort: 'name', 
+        sort_dir: 'ASC',
+      })
+
+      expect(result.items[0].name).toEqual('a')
+      expect(result.items[1].name).toEqual('b')
+      expect(result.items.length).toEqual(2)
+
+      result = await ormRepository.search({ 
+        page: 1, 
+        per_page: 2, 
+        filter: null, 
+        sort: 'name', 
+        sort_dir: 'DES',
+      })
+
+      expect(result.items[0].name).toEqual('e')
+      expect(result.items[1].name).toEqual('d')
+      expect(result.items.length).toEqual(2)
+
+  })
 });


### PR DESCRIPTION
**Descrição**

Este PR adiciona um teste unitário que garante o correto funcionamento da paginação e ordenação no repositório de produtos.

O teste cobre os seguintes cenários:

- Ordenação ascendente (ASC) pelo campo name.

- Ordenação descendente (DESC) pelo campo name.

- Paginação respeitando os parâmetros page e per_page.

**Alterações realizadas**

- Adicionado novo caso de teste it('should apply paginate and sort', ...) em ProductRepository.spec.ts.