### PR TITLE
Adiciona testes de validação e conflito na criação de produto

### DIFF
--- a/src/products/aplication/usecases/create-product.usecase.spec.ts
+++ b/src/products/aplication/usecases/create-product.usecase.spec.ts
@@ -1,6 +1,8 @@
 import { ProductsRepository } from "@/products/domain/respositories/products.respository"
 import { CreateProductUseCase } from "./create-product.usecase"
 import { ProductsInMemoryRepository } from "@/products/infrastructure/in-memory/repositories/products-in-memory.repository"
+import { ConflictError } from "@/common/domain/errors/not-found-conflict-error"
+import { BadRequestError } from "@/common/domain/errors/bad-request-error"
 
 describe('CreateProductUseCase Unit Tests', () => {
   
@@ -23,6 +25,41 @@ describe('CreateProductUseCase Unit Tests', () => {
     expect(result.id).toBeDefined()
     expect(result.created_at).toBeDefined()
     expect(spyInsert).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not be possible to register a product with the name of another product', async () => {
+    const props = {
+      name: 'Product 1',
+      price: 10,
+      quantity: 5
+    }
+    await sut.execute(props)
+    await expect(sut.execute(props)).rejects.toBeInstanceOf(ConflictError)
+  })
+
+  it('should throw error when name not provided', async () => {
+    const props = {
+      name: null,
+      price: 10,
+      quantity: 5
+    }
+    await expect(sut.execute(props)).rejects.toBeInstanceOf(BadRequestError)
+  })
+  it('should throw error when price not provided', async () => {
+    const props = {
+      name: 'Product 1',
+      price: 0,
+      quantity: 5
+    }
+    await expect(sut.execute(props)).rejects.toBeInstanceOf(BadRequestError)
+  })
+  it('should throw error when quantity not provided', async () => {
+    const props = {
+      name: 'Product 1',
+      price: 10,
+      quantity: 0
+    }
+    await expect(sut.execute(props)).rejects.toBeInstanceOf(BadRequestError)
   })
 
 })

--- a/src/products/aplication/usecases/create-product.usecase.ts
+++ b/src/products/aplication/usecases/create-product.usecase.ts
@@ -22,24 +22,23 @@ export namespace CreateProductUseCase {
     constructor(private productsRepository: ProductsRepository) {}
 
     async execute(input: Input): Promise<Output> {
-        if (!input.name || input.price <= 0 || input.quantity <= 0) {
-            throw new BadRequestError("Input data not provided or invalid");
-        }
+      if (!input.name || input.price <= 0 || input.quantity <= 0) {
+          throw new BadRequestError("Input data not provided or invalid");
+      }
 
-        await this.productsRepository.conflictingName(input.name);
+      await this.productsRepository.conflictingName(input.name);
 
-        const product = this.productsRepository.create(input);
-        await this.productsRepository.insert(product);
+      const product = this.productsRepository.create(input);
+      await this.productsRepository.insert(product);
 
-        return {
-            id: product.id,
-            name: product.name,
-            price: product.price,
-            quantity: product.quantity,
-            created_at: product.created_at,
-            updated_at: product.updated_at
-        };
+      return {
+          id: product.id,
+          name: product.name,
+          price: product.price,
+          quantity: product.quantity,
+          created_at: product.created_at,
+          updated_at: product.updated_at
+      };
     }
-
   }
 }


### PR DESCRIPTION
Este PR adiciona uma suite de testes para garantir a consistência na criação de produtos, cobrindo os seguintes cenários:

Não permitir o registro de um produto com o mesmo nome de um já existente.

**Validar campos obrigatórios, lançando BadRequestError quando:**

- name não for informado.

- price for 0 ou não informado.

- quantity for 0 ou não informado.

Esses testes reforçam a integridade da regra de negócio para cadastro de produtos.

 **Alterações realizadas**

- Adicionados testes unitários para o caso de conflito de nome de produto.

- Adicionados testes unitários para validação de campos obrigatórios (name, price, quantity).