### PR TITLE
feat: criação da entidade Product com datas automáticas

### DIFF
--- a/src/common/infrastructure/typeorm/index.ts
+++ b/src/common/infrastructure/typeorm/index.ts
@@ -14,3 +14,4 @@ export const dataSource = new DataSource({
   synchronize: false,
   logging: false,
 });
+ 

--- a/src/products/infrastructure/typeorm/entities/products.entity.ts
+++ b/src/products/infrastructure/typeorm/entities/products.entity.ts
@@ -1,5 +1,5 @@
 import { ProductModel } from '@/products/domain/models/products.model';
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
 
 @Entity('products')
 export class Product implements ProductModel {
@@ -9,15 +9,18 @@ export class Product implements ProductModel {
   @Column('varchar')
   name: string;
 
-  @Column('decimal')
+  @Column('decimal', { transformer: {
+    to: (value: number) => value,
+    from: (value: string) => parseFloat(value)
+  }})
   price: number;
 
   @Column('int')
   quantity: number;
 
-  @Column({name: 'created_at'})
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;
 
-  @Column({name: 'updated_at'})
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
   updated_at: Date;
 }


### PR DESCRIPTION
Este PR adiciona a entidade Product utilizando TypeORM, implementando o modelo ProductModel.

**Alterações realizadas:**

created_at → preenchimento automático na criação (@CreateDateColumn).

updated_at → atualização automática (@UpdateDateColumn).

Uso de timestamp com CURRENT_TIMESTAMP para compatibilidade com o banco.

Transformador aplicado para price para lidar com a conversão entre decimal e number.