### PR TITLE
feat(products): cria casos de uso e configuração de injeção de dependências

### DIFF
--- a/src/products/aplication/usecases/get-product.usecase.ts
+++ b/src/products/aplication/usecases/get-product.usecase.ts
@@ -1,0 +1,41 @@
+import { BadRequestError } from "@/common/domain/errors/bad-request-error"
+import { ProductsRepository } from "@/products/domain/respositories/products.respository"
+import { inject, injectable } from "tsyringe"
+
+export namespace getProductUseCase {
+  export type Input = {
+    id: string
+  }
+
+  export type Output = {
+    id: string
+    name: string
+    price: number
+    quantity: number  
+    created_at: Date
+    updated_at: Date
+  }
+
+  @injectable()
+  export class UseCase {
+
+    constructor(
+      @inject('ProductRepository')
+      private productsRepository: ProductsRepository,
+    ) {}
+
+    async execute(input: Input): Promise<Output> {
+
+      const product = await this.productsRepository.findById(input.id);
+
+      return {
+          id: product.id,
+          name: product.name,
+          price: product.price,
+          quantity: product.quantity,
+          created_at: product.created_at,
+          updated_at: product.updated_at
+      };
+    }
+  }
+}

--- a/src/products/infrastructure/container/index.ts
+++ b/src/products/infrastructure/container/index.ts
@@ -1,5 +1,6 @@
 import { container } from 'tsyringe';
 import { CreateProductUseCase } from '@/products/aplication/usecases/create-product.usecase';
+import { getProductUseCase } from '@/products/aplication/usecases/get-product.usecase';
 import { Product } from '@/products/infrastructure/typeorm/entities/products.entity';
 import { ProductsTypeormRepository } from '@/products/infrastructure/typeorm/respositories/products-typeorm.repository';
 import { dataSource } from '@/common/infrastructure/typeorm';
@@ -11,3 +12,5 @@ container.registerInstance(
   'ProductsDefaultTypeormRepository',
   dataSource.getRepository(Product)
 ) 
+
+container.registerSingleton('getProductUseCase', getProductUseCase.UseCase);


### PR DESCRIPTION
 Este PR adiciona e configura os casos de uso relacionados a produtos.

Implementado o caso de uso getProductUseCase para buscar produto por ID.

Configurado o container do tsyringe para registrar os repositórios e casos de uso.

Adicionada a injeção do ProductsTypeormRepository e da entidade Product.

**Alterações**

Novo caso de uso

getProductUseCase.UseCase: retorna os dados de um produto existente.

**Configuração de dependências**

Registro do ProductsTypeormRepository como ProductRepository.

Registro do CreateProductUseCase e getProductUseCase no container.

Registro do repositório default do TypeORM (ProductsDefaultTypeormRepository).