### PR TITLE
test(products): adiciona testes unitários para getProductUseCase

### DIFF
--- a/src/products/aplication/usecases/get-product.usecase.spec.ts
+++ b/src/products/aplication/usecases/get-product.usecase.spec.ts
@@ -1,0 +1,44 @@
+import "reflect-metadata"
+import { ProductsRepository } from "@/products/domain/respositories/products.respository"
+import { getProductUseCase } from "./get-product.usecase"
+import { ProductsInMemoryRepository } from "@/products/infrastructure/in-memory/repositories/products-in-memory.repository"
+import { ConflictError } from "@/common/domain/errors/not-found-conflict-error"
+import { BadRequestError } from "@/common/domain/errors/bad-request-error"
+import { Not } from "typeorm"
+import { NotFoundError } from "@/common/domain/errors/not-found-error"
+
+describe('GetProductUseCase Unit Tests', () => {
+  
+  let sut: getProductUseCase.UseCase
+  let repository: ProductsRepository
+
+  beforeEach(() => {
+    repository = new ProductsInMemoryRepository()
+    sut = new getProductUseCase.UseCase(repository)
+  })
+
+  it('should be able to get a product', async () => {
+    const spyFinById = jest.spyOn(repository, 'findById')
+    const props = {
+      name: 'Product 1',
+      price: 10,
+      quantity: 5
+    }
+
+    const model = repository.create(props)
+    await repository.insert(model)
+
+    const result = await sut.execute({id: model.id })
+    expect(result).toMatchObject(model)
+    expect(spyFinById).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throws error when product not found', async () => {
+
+    await expect(sut.execute({id: 'fake-id' })).rejects.toBeInstanceOf(
+      NotFoundError,
+    )
+  })
+
+
+})


### PR DESCRIPTION
Este PR adiciona testes unitários para o caso de uso getProductUseCase.

Implementado teste para verificar se um produto pode ser recuperado com sucesso.

Implementado teste para verificar o lançamento de erro quando o produto não é encontrado.

Utilizado repositório em memória (ProductsInMemoryRepository) para isolar a lógica do caso de uso sem dependência externa.

**Alterações**

Criado arquivo de testes para getProductUseCase.

Cobertura dos seguintes cenários:

Recuperação de um produto existente.

Erro ao tentar recuperar produto inexistente.