### PR TITLE
Implementação do DTO ProductOutput no caso de uso de criação de produto

### DIFF
--- a/src/products/aplication/dtos/product-output.dto.ts
+++ b/src/products/aplication/dtos/product-output.dto.ts
@@ -1,0 +1,8 @@
+export type ProductOutput = {
+    id: string
+    name: string
+    price: number
+    quantity: number  
+    created_at: Date
+    updated_at: Date
+  }

--- a/src/products/aplication/usecases/create-product.usecase.ts
+++ b/src/products/aplication/usecases/create-product.usecase.ts
@@ -1,6 +1,7 @@
 import { BadRequestError } from "@/common/domain/errors/bad-request-error"
 import { ProductsRepository } from "@/products/domain/respositories/products.respository"
 import { inject, injectable } from "tsyringe"
+import { ProductOutput } from "../dtos/product-output.dto"
 
 export namespace CreateProductUseCase {
   export type Input = {
@@ -9,14 +10,7 @@ export namespace CreateProductUseCase {
     quantity: number
   }
 
-  export type Output = {
-    id: string
-    name: string
-    price: number
-    quantity: number  
-    created_at: Date
-    updated_at: Date
-  }
+  export type Output = ProductOutput
 
   @injectable()
   export class UseCase {
@@ -34,16 +28,9 @@ export namespace CreateProductUseCase {
       await this.productsRepository.conflictingName(input.name);
 
       const product = this.productsRepository.create(input);
-      await this.productsRepository.insert(product);
+      const createdProduct: ProductOutput = await this.productsRepository.insert(product);
 
-      return {
-          id: product.id,
-          name: product.name,
-          price: product.price,
-          quantity: product.quantity,
-          created_at: product.created_at,
-          updated_at: product.updated_at
-      };
+      return createdProduct
     }
   }
 }

--- a/src/products/aplication/usecases/get-product.usecase.ts
+++ b/src/products/aplication/usecases/get-product.usecase.ts
@@ -1,20 +1,14 @@
 import { BadRequestError } from "@/common/domain/errors/bad-request-error"
 import { ProductsRepository } from "@/products/domain/respositories/products.respository"
 import { inject, injectable } from "tsyringe"
+import { ProductOutput } from "../dtos/product-output.dto"
 
 export namespace getProductUseCase {
   export type Input = {
     id: string
   }
 
-  export type Output = {
-    id: string
-    name: string
-    price: number
-    quantity: number  
-    created_at: Date
-    updated_at: Date
-  }
+  export type Output = ProductOutput
 
   @injectable()
   export class UseCase {
@@ -26,16 +20,10 @@ export namespace getProductUseCase {
 
     async execute(input: Input): Promise<Output> {
 
-      const product = await this.productsRepository.findById(input.id);
+      const product: ProductOutput = await this.productsRepository.findById(input.id);
 
-      return {
-          id: product.id,
-          name: product.name,
-          price: product.price,
-          quantity: product.quantity,
-          created_at: product.created_at,
-          updated_at: product.updated_at
-      };
+      return product;
+
     }
   }
 }


### PR DESCRIPTION
Este pull request adiciona a utilização do DTO ProductOutput no caso de uso (UseCase) de criação de produtos, garantindo que a saída da função seja padronizada e segura.

Principais alterações:

Validação de input:

Verifica se name está presente e se price e quantity são maiores que zero.

Lança BadRequestError em caso de dados inválidos.

**Checagem de conflito de nome:**

- Utiliza productsRepository.conflictingName(input.name) para prevenir duplicidades.

-  Criação e inserção do produto:

- Cria a entidade do produto (create).

- Insere no repositório (insert) e retorna o DTO ProductOutput.

**Retorno padronizado:**

- O método execute retorna ProductOutput, garantindo consistência na saída para a camada de apresentação.