### PR TITLE
feat: implementar caso de uso para atualização de produto

### DIFF
--- a/src/products/aplication/usecases/update-product.usecase.ts
+++ b/src/products/aplication/usecases/update-product.usecase.ts
@@ -1,0 +1,44 @@
+import { ProductsRepository } from "@/products/domain/respositories/products.respository"
+import { inject, injectable } from "tsyringe"
+import { ProductOutput } from "../dtos/product-output.dto"
+
+export namespace UpdateProductUseCase {
+  export type Input = {
+    id: string
+    name?: string
+    price?: number
+    quantity?: number
+  }
+
+  export type Output = ProductOutput
+
+  @injectable()
+  export class UseCase {
+
+    constructor(
+      @inject('ProductRepository')
+      private productsRepository: ProductsRepository,
+    ) {}
+
+    async execute(input: Input): Promise<Output> {
+
+      const product = await this.productsRepository.findById(input.id);
+
+      if (input.name){
+        product.name = input.name
+      }
+
+      if (input.price){
+        product.price = input.price
+      }
+      
+      if (input.quantity){
+        product.quantity = input.quantity
+      }
+
+      const updatedProduct: ProductOutput = await this.productsRepository.update(product);
+
+      return updatedProduct
+    }
+  }
+}

--- a/src/products/infrastructure/container/index.ts
+++ b/src/products/infrastructure/container/index.ts
@@ -1,5 +1,6 @@
 import { container } from 'tsyringe';
 import { CreateProductUseCase } from '@/products/aplication/usecases/create-product.usecase';
+import { UpdateProductUseCase } from '@/products/aplication/usecases/update-product.usecase';
 import { getProductUseCase } from '@/products/aplication/usecases/get-product.usecase';
 import { Product } from '@/products/infrastructure/typeorm/entities/products.entity';
 import { ProductsTypeormRepository } from '@/products/infrastructure/typeorm/respositories/products-typeorm.repository';
@@ -14,3 +15,5 @@ container.registerInstance(
 ) 
 
 container.registerSingleton('getProductUseCase', getProductUseCase.UseCase);
+
+container.registerSingleton('updateProductUseCase', UpdateProductUseCase.UseCase);


### PR DESCRIPTION
### O que foi feito
- Criado `UpdateProductUseCase` responsável por atualizar os dados de um produto existente.
- Definido contrato de entrada (`Input`) com os campos:
  - id (obrigatório)
  - name (opcional)
  - price (opcional)
  - quantity (opcional)
- Implementada lógica de atualização:
  - Busca do produto pelo ID.
  - Atualização dos campos somente se enviados.
  - Persistência da alteração no repositório.
- Criado tipo de saída (`Output`) baseado em `ProductOutput`.
- Registrado o caso de uso no container de injeção de dependências:
  - `container.registerSingleton('updateProductUseCase', UpdateProductUseCase.UseCase);`

### Benefícios
- Possibilita atualização parcial de produtos sem necessidade de sobrescrever todos os campos.
- Padroniza o uso de casos de uso com injeção de dependências (`tsyringe`).
- Facilita a integração com controladores e serviços da aplicação.