### PR TITLE
feat: criação do caso de uso DeleteProductUseCase

### DIFF
--- a/src/products/aplication/usecases/delete-product.usecase.ts
+++ b/src/products/aplication/usecases/delete-product.usecase.ts
@@ -1,0 +1,23 @@
+import { ProductsRepository } from "@/products/domain/respositories/products.respository"
+import { inject, injectable } from "tsyringe"
+
+export namespace DeleteProductUseCase {
+  export type Input = {
+    id: string
+  }
+
+  export type Output = void
+
+  @injectable()
+  export class UseCase {
+
+    constructor(
+      @inject('ProductRepository')
+      private productsRepository: ProductsRepository,
+    ) {} 
+
+    async execute(input: Input): Promise<Output> {
+      await this.productsRepository.findById(input.id);
+    }
+  }
+}

--- a/src/products/infrastructure/container/index.ts
+++ b/src/products/infrastructure/container/index.ts
@@ -5,6 +5,7 @@ import { getProductUseCase } from '@/products/aplication/usecases/get-product.us
 import { Product } from '@/products/infrastructure/typeorm/entities/products.entity';
 import { ProductsTypeormRepository } from '@/products/infrastructure/typeorm/respositories/products-typeorm.repository';
 import { dataSource } from '@/common/infrastructure/typeorm';
+import { DeleteProductUseCase } from '@/products/aplication/usecases/delete-product.usecase';
 
 container.registerSingleton('ProductRepository', ProductsTypeormRepository);
 container.registerSingleton('CreateProductUseCase', CreateProductUseCase.UseCase);
@@ -17,3 +18,5 @@ container.registerInstance(
 container.registerSingleton('getProductUseCase', getProductUseCase.UseCase);
 
 container.registerSingleton('updateProductUseCase', UpdateProductUseCase.UseCase);
+
+container.registerSingleton('deleteProductUseCase', DeleteProductUseCase.UseCase);


### PR DESCRIPTION
Este PR adiciona o **caso de uso para exclusão de produtos (`DeleteProductUseCase`)**, seguindo a arquitetura de casos de uso e aplicando injeção de dependência com `tsyringe`.

* Criada a estrutura `DeleteProductUseCase` dentro do namespace correspondente.
* Definição de `Input` (parâmetro esperado: `id: string`).
* Definição de `Output` (sem retorno – `void`).
* Implementação inicial da lógica de exclusão.

---

### Alterações Principais

* Novo arquivo contendo:

  * Tipo `Input` com `id`.
  * Tipo `Output` definido como `void`.
  * Classe `UseCase` injetando `ProductsRepository`.
  * Método `execute` que por enquanto realiza a busca pelo produto (`findById`).

