### PR TITLE
Feat: adicionar controller para exclusão de produto

### DIFF
--- a/src/products/infrastructure/container/index.ts
+++ b/src/products/infrastructure/container/index.ts
@@ -11,7 +11,7 @@ container.registerSingleton('ProductRepository', ProductsTypeormRepository);
 container.registerSingleton('CreateProductUseCase', CreateProductUseCase.UseCase);
 
 container.registerInstance(
-  'ProductsDefaultTypeormRepository',
+'ProductsDefaultTypeormRepository',
   dataSource.getRepository(Product)
 ) 
 

--- a/src/products/infrastructure/http/controllers/delete-product.controller.ts
+++ b/src/products/infrastructure/http/controllers/delete-product.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { DeleteProductUseCase } from "@/products/aplication/usecases/delete-product.usecase";
+import { container } from "tsyringe";
+import { dataValidation } from "@/common/infrastructure/validation/zod";
+
+export async function deleteProductController(
+  request: Request,
+  response: Response,
+) {
+  const deleteProductBodySchema = z.object({
+    id: z.string(),
+  })
+ 
+  const { id } = dataValidation(deleteProductBodySchema, request.params)
+
+  const deleteProductUseCase: DeleteProductUseCase.UseCase = container.resolve('DeleteProductUseCase')
+
+  const product = await deleteProductUseCase.execute({ id })
+
+  return response.status(204).json(product)
+}

--- a/src/products/infrastructure/http/routes/products.route.ts
+++ b/src/products/infrastructure/http/routes/products.route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { createProductController } from '../controllers/create-product.controller'
 import { getProductController } from '../controllers/get-product.controller'
 import { updateProductController } from '../controllers/update-product.controller'
+import { deleteProductController } from '../controllers/delete-product.controller'
 
 const productsRouter = Router()
 
@@ -140,5 +141,7 @@ productsRouter.get('/:id', getProductController)
  */
 
 productsRouter.put('/:id', updateProductController)
+
+productsRouter.put('/:id', deleteProductController)
 
 export { productsRouter }


### PR DESCRIPTION
**Descrição**

Este PR adiciona o controller deleteProductController, responsável por realizar a exclusão de produtos a partir do id recebido nos parâmetros da requisição.

**Alterações principais**

- Criação do controller deleteProductController em @/products/infrastructure/controllers.

- Implementação da validação de dados utilizando Zod.

- Utilização do dataValidation para validar o parâmetro id.

- Injeção de dependência com tsyringe para resolver o caso de uso DeleteProductUseCase.

- Retorno de HTTP 204 (No Content) em caso de exclusão bem-sucedida.